### PR TITLE
Added: toggle feature to both the passwords using eye buttons

### DIFF
--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { FaUser, FaEnvelope, FaLock, FaKey } from "react-icons/fa";
+import { FaUser, FaEnvelope, FaLock, FaKey, FaEyeSlash, FaEye } from "react-icons/fa";
 import Footer from "../components/common/Footer";
 import { useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
@@ -16,6 +16,17 @@ const SignUp = () => {
   const [password, setPassword] = useState("");
   const [confirmPassword, setconfirmPassword] = useState("");
   const [username, setUsername] = useState("");
+  const [showPassword, setshowPassword] = useState(false);
+  const [showConfirmPassword, setshowConfirmPassword] = useState(false);
+
+  // toggle password
+  const togglePassword = () => {
+    setshowPassword(!showPassword);
+  }
+
+  const toggleConfirmPassword = () => {
+    setshowConfirmPassword(!showConfirmPassword);
+  }
 
   const handleOnChange = (e) => {
     if (e.target.name === "firstName") {
@@ -121,28 +132,40 @@ const SignUp = () => {
             </div>
             <div className="flex items-center mb-4">
               <FaLock className="text-lg me-3" />
-              <div className="form-outline flex-grow">
+              <div className="form-outline flex-grow flex items-center relative">
                 <input
-                  type="password"
+                  type={showPassword ? "text" : "password"}
                   name="password"
                   value={password}
                   onChange={handleOnChange}
                   className="form-control form-control px-3 py-2 rounded-3xl border-2 border-black w-full"
                   placeholder="Password"
                 />
+                {
+                  password ? 
+                <span className="absolute right-3 cursor-pointer">
+                  {showPassword ? <FaEyeSlash onClick={togglePassword} className="text-base" /> : <FaEye onClick={togglePassword} className="text-base" />}
+                </span>
+                : <></>}
               </div>
             </div>
             <div className="flex items-center mb-4  rounded-sm border-black w-full">
               <FaKey className="text-lg me-3" />
-              <div className="form-outline flex-grow">
+              <div className="form-outline flex-grow flex items-center relative">
                 <input
-                  type="confirmPassword"
+                  type={showConfirmPassword ? "text" : "password"}
                   name="confirmPassword"
                   value={confirmPassword}
                   onChange={handleOnChange}
                   className="form-control form-control px-3 py-2 rounded-3xl border-2 border-black w-full"
                   placeholder="Repeat your password"
                 />
+                {
+                  confirmPassword ? 
+                <span className="absolute right-3 cursor-pointer">
+                  {showConfirmPassword ? <FaEyeSlash onClick={toggleConfirmPassword} className="text-base" /> : <FaEye onClick={toggleConfirmPassword} className="text-base" />}
+                </span>
+                : <></>}
               </div>
             </div>
 


### PR DESCRIPTION
## Description
For the SignUp page: When the user starts typing in the password or confirm password field, first the password is masked and an eye appears, on clicking it, it changes to eye slash an the password is visible, on clicking it again passwords gets hided with eye slash icon changing back to eye icon.
For the Login page: the feature was already there. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Motivation and Context
To help the user to show the password they are typing so that they do not nedd to re-enter it in case of mistyping.
Thus they can see it using this feature.

## Screenshots:
![Screenshot (748)](https://github.com/user-attachments/assets/66ce5bb3-367f-43b9-b302-010a468eb4f9)
![Screenshot (753)](https://github.com/user-attachments/assets/6e903df3-6e61-45fc-95ed-ce518e706bd6)

For the Login page, it was already added:
![Screenshot (750)](https://github.com/user-attachments/assets/4142fd0b-15e5-4c6f-8565-790104cb59fd)

## Checklist:
- [x] I have registered myself at [Contrihub website](https://sac.mnnit.ac.in/contrihub).
- [x] My code follows the code style of this project.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.